### PR TITLE
Bugfix: missing libraries

### DIFF
--- a/check_puppetdb.rb
+++ b/check_puppetdb.rb
@@ -8,6 +8,7 @@
 #
 # http://docs.puppetlabs.com/puppetdb/latest/api/query/v2/metrics.html
 
+require 'rubygems'
 require 'optparse'
 require 'open-uri'
 require 'uri'


### PR DESCRIPTION
Hi,

when trying to run the check the first time I got the error of missing json:

$ check_puppetdb.rb:14:in `require': no such file to load -- json (LoadError)
    from check_puppetdb.rb:14

I solved it by adding the rubygems requirement
