### PR TITLE
Documentation: added ruby version

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,6 +5,8 @@ PuppetDB monitoring script for Nagios/Icinga/Shinken
 
 Using PuppetDB API (http://docs.puppetlabs.com/puppetdb/latest/api/query/v3/metrics.html) to query certain metrics for monitoring and statistic purposes.
 
+Ruby version: 1.9.3
+
 USAGE:
 --------
 


### PR DESCRIPTION
Hi,

I struggled to get it working on a centos 6 machine. It turned out the default ruby version installed from the standard repositories is 1.8.7 and therefore I got this error:

  check_puppetdb.rb:72:in `doRequest': uninitialized constant Timeout (NameError)
    from check_puppetdb.rb:84:in`commandProcessingMetrics'
    from check_puppetdb.rb:249

Once I installed ruby 1.9.3 the check_puppetdb worked fine as it should be!

I added the ruby version 1.9.3 to the README file just as a reference for other user :)
