### PR TITLE
Don't fail on low command rates by default

### DIFF
--- a/check_puppetdb.rb
+++ b/check_puppetdb.rb
@@ -24,8 +24,8 @@ $port = 8080
 $sslport = $port + 1
 $queuewarn = 500
 $queuecrit = 2000
-$cmd_p_secwarn = 0.5
-$cmd_p_seccrit = 0.2
+$cmd_p_secwarn = -1
+$cmd_p_seccrit = -1
 
 opt = OptionParser.new
 opt.on("--debug", "-d", "print debug information, defaults to #{$debug}") do |f|


### PR DESCRIPTION
Cmd_p_secwarn and cmd_p_seccrit allow this behavior to be adjusted.
This change is useful for PuppetDB servers that aren't crunching hard numbers 24/7.
