### PR TITLE
don't put threads=N/A into nagios performance data

### DIFF
--- a/check_puppetdb.rb
+++ b/check_puppetdb.rb
@@ -359,7 +359,7 @@ def queueMetrics(warn, crit)
       rc = 0
     end
     result['returncode'] = rc
-    if $api_version.match(/^(4\.3)/)
+    if $api_version.match(/^(4\.[3-9]+)/)
       result['text'] = "#{text}Queue size: #{queueSize}"
       result['perfdata'] = "queue_size=#{queueSize};#{warn};#{crit}"
     else


### PR DESCRIPTION
I think this is preventing me from drawing the graphs so either not put it into the perf data or put a literal U ("value may be a literal "U" instead, this would indicate that the actual value couldn't be determined" from nagios docs)

Greetings
Klaas